### PR TITLE
Implement load priority default and descending order support for row rearrangement

### DIFF
--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
@@ -388,17 +388,4 @@ public class MainWindowView {
 			modTable.getSortOrder().addListener(sortListener);
 		}
 	}
-
-	//TODO:
-
-	//TODO: Add code for onSort. Check when onSort is called if a current sort is active, and if not, sort based on priority. This handles the "none" sort case you get after ascend then descend sorting.
-	/* This is a helpful example on how to do it
-	if (!modTableView.getSortOrder().isEmpty()) {
-				TableColumn<Mod, ?> sortedColumn = modTableView.getSortOrder().getFirst();
-				TableColumn.SortType sortedColumnSortType = modTableView.getSortOrder().getFirst().getSortType();
-				sortedColumn.setSortType(null);
-				modTableView.refresh();
-				sortedColumn.setSortType(sortedColumnSortType);
-			}
-	 */
 }

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
@@ -9,6 +9,7 @@ import com.gearshiftgaming.se_mod_manager.frontend.models.ModNameCell;
 import com.gearshiftgaming.se_mod_manager.frontend.models.ModTableRowFactory;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -141,7 +142,9 @@ public class MainWindowView {
 	//This is the reference to the controller for the bar located in the bottom section of the main borderpane
 	private final StatusBarView STATUS_BAR_VIEW;
 
-	final DataFormat SERIALIZED_MIME_TYPE;
+	private final DataFormat SERIALIZED_MIME_TYPE;
+
+	private final ListChangeListener<TableColumn<Mod, ?>> sortListener;
 
 	//Initializes our controller while maintaining the empty constructor JavaFX expects
 	public MainWindowView(Properties properties, Stage stage,
@@ -158,6 +161,12 @@ public class MainWindowView {
 		SAVE_PROFILES = uiService.getSAVE_PROFILES();
 
 		SERIALIZED_MIME_TYPE = new DataFormat("application/x-java-serialized-object");
+
+		sortListener = change -> {
+			if(modTable.getSortOrder().isEmpty()) {
+				applyDefaultSort();
+			}
+		};
 	}
 
 	public void initView(Parent mainViewRoot, Parent menuBarRoot, Parent statusBarRoot) throws XmlPullParserException, IOException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
@@ -300,6 +309,7 @@ public class MainWindowView {
 			return new SimpleStringProperty(sb.toString());
 		});
 
+		modTable.getSortOrder().addListener(sortListener);
 
 		modTable.setItems(UI_SERVICE.getCurrentModList());
 	}
@@ -364,6 +374,19 @@ public class MainWindowView {
 			mainViewSplitDividerVisible = true;
 		}
 		mainViewSplit.setDividerPosition(0, 0.7);
+	}
+
+	private void applyDefaultSort() {
+		if(loadPriority != null) {
+			modTable.getSortOrder().removeListener(sortListener);
+
+			loadPriority.setSortType(TableColumn.SortType.ASCENDING);
+			modTable.getSortOrder().add(loadPriority);
+			modTable.sort();
+			modTable.getSortOrder().clear();
+
+			modTable.getSortOrder().addListener(sortListener);
+		}
 	}
 
 	//TODO:

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
@@ -282,7 +282,7 @@ public class MainWindowView {
 	private void setupModTable() {
 
 		modTable.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
-		modTable.setRowFactory(new ModTableRowFactory(UI_SERVICE, SERIALIZED_MIME_TYPE));
+		modTable.setRowFactory(new ModTableRowFactory(UI_SERVICE, SERIALIZED_MIME_TYPE, STAGE));
 
 		modName.setCellValueFactory(cellData -> new ReadOnlyObjectWrapper<>(cellData.getValue()));
 		modName.setCellFactory(param -> new ModNameCell(UI_SERVICE));

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/StatusBarView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/StatusBarView.java
@@ -22,6 +22,7 @@ import java.util.UUID;
  * this file. If not, please write to: gearshift@gearshiftgaming.com.
 
  */
+//TODO: Add border to top
 public class StatusBarView {
 
 	@FXML


### PR DESCRIPTION
Implements functionality to make it so that, when a user clears the sorting on any column, we default to having it sort by ascending load priority. This is done by adding a listener to the sortOrder property of the mod table, and calling code that sets the default order to ascending load priority. In the function called, the listener is removed, the load priority set, then the listener added back to prevent a stack overflow error.

Additionally, support is added to enable the load priority to be properly rearranged when the column is sorted in a descending order. This is done by performing a check to see if we are either in ascending or not sorted order on the load priority column, and if we are then we iterate through each item of the list and set their load priority equal to an index +1. If we are not in ascending or no sorted order, we do the same thing but set the load priority for each item to the inverted position of our index.
