### PR TITLE
Implemented autoscrolling for mod table

### DIFF
--- a/src/main/java/com/gearshiftgaming/se_mod_manager/controller/ViewController.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/controller/ViewController.java
@@ -100,7 +100,7 @@ public class ViewController {
 		}
 	}
 
-	//TODO: Move the modtable to its own FXML file and classes due to complexity.
+	//TODO: Move all the content in the center of the MainWindowView into its own fxml and class file.
 	private void setupInterface(Stage stage) throws IOException, XmlPullParserException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
 		//Manually inject our controllers into our FXML so we can reuse the FXML for the profile creation elsewhere, and have greater flexibility in controller injection and FXML initialization.
 		//This method also allows us to properly define constructors for the view objects which is otherwise not feasible with JavaFX.

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/controller/ViewController.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/controller/ViewController.java
@@ -100,6 +100,7 @@ public class ViewController {
 		}
 	}
 
+	//TODO: Move the modtable to its own FXML file and classes due to complexity.
 	private void setupInterface(Stage stage) throws IOException, XmlPullParserException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
 		//Manually inject our controllers into our FXML so we can reuse the FXML for the profile creation elsewhere, and have greater flexibility in controller injection and FXML initialization.
 		//This method also allows us to properly define constructors for the view objects which is otherwise not feasible with JavaFX.

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRow.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRow.java
@@ -52,6 +52,7 @@ public class ModTableRow extends TableRow<Mod> {
 		}
 	}
 
+	//TODO: Maybe make them a brighter color? Like, for light make it blue. Not sure for darks. Red? Green for Dracula? Some better color contrast would work a LOT better.
 	//This is an extremely clunky way of doing this, and it's pretty dependent on the atlantaFX implementation, but I'm an idiot and can't figure out another way to actually get the damn current CSS style from my stylesheet, then add onto it.
 	private String getSelectedCellColor(String themeName) {
 		return switch (themeName) {

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
@@ -43,16 +43,19 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 
 	private TableRow<Mod> previousRow;
 
+	private final List<TableRow<Mod>> SINGLE_TABLE_ROW;
+
 	private enum RowBorderType {
 		TOP,
 		BOTTOM
 	}
 
 
-	public ModTableRowFactory(UiService uiService, DataFormat serializedMimeType, List<Mod> selections) {
+	public ModTableRowFactory(UiService uiService, DataFormat serializedMimeType, List<Mod> selections, List<TableRow<Mod>> singleTableRow) {
 		this.UI_SERVICE = uiService;
 		this.SERIALIZED_MIME_TYPE = serializedMimeType;
 		this.SELECTIONS = selections;
+		this.SINGLE_TABLE_ROW = singleTableRow;
 	}
 
 
@@ -270,6 +273,10 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 			dragEvent.consume();
 		});
 
+		//This is a dumb hack but I can't get the damn rows any other way
+		if(SINGLE_TABLE_ROW.isEmpty()) {
+			SINGLE_TABLE_ROW.add(row);
+		}
 		return row;
 	}
 

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
@@ -33,7 +33,6 @@ import java.util.List;
  * this file. If not, please write to: gearshift@gearshiftgaming.com.
  */
 
-//TODO: Add autoscrolling when going beyond visible pane https://stackoverflow.com/questions/46471987/javafx-auto-scroll-table-up-or-down-when-dragging-rows-outside-of-viewport#46479277
 //TODO: Make the rows have a specific color with possible pattern like hatching or diagonal lines based on status or conflicts and stuff
 public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod>> {
 

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
@@ -16,8 +16,9 @@ import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.util.Callback;
+import javafx.scene.control.ScrollBar;
 
-import java.awt.*;
+import java.awt.Desktop;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -44,12 +45,10 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 
 	private final ArrayList<Mod> SELECTIONS;
 
-	private final Stage STAGE;
 
-	public ModTableRowFactory(UiService uiService, DataFormat serializedMimeType, Stage stage) {
+	public ModTableRowFactory(UiService uiService, DataFormat serializedMimeType) {
 		this.UI_SERVICE = uiService;
 		this.SERIALIZED_MIME_TYPE = serializedMimeType;
-		this.STAGE = stage;
 		SELECTIONS = new ArrayList<>();
 	}
 
@@ -147,6 +146,7 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 			}
 		});
 
+		//TODO: not sure where it's breaking, but I can't drag to the bottom of the list anymore.
 		row.setOnDragOver(dragEvent -> {
 			Dragboard dragboard = dragEvent.getDragboard();
 			if (dragboard.hasContent(SERIALIZED_MIME_TYPE)) {

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
@@ -17,6 +17,7 @@ import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.util.Callback;
 import javafx.scene.control.ScrollBar;
+import lombok.Getter;
 
 import java.awt.Desktop;
 import java.io.IOException;
@@ -42,14 +43,13 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 	private final UiService UI_SERVICE;
 
 	private final DataFormat SERIALIZED_MIME_TYPE;
+	private final List<Mod> SELECTIONS;
 
-	private final ArrayList<Mod> SELECTIONS;
 
-
-	public ModTableRowFactory(UiService uiService, DataFormat serializedMimeType) {
+	public ModTableRowFactory(UiService uiService, DataFormat serializedMimeType, List<Mod> selections) {
 		this.UI_SERVICE = uiService;
 		this.SERIALIZED_MIME_TYPE = serializedMimeType;
-		SELECTIONS = new ArrayList<>();
+		this.SELECTIONS = selections;
 	}
 
 
@@ -147,6 +147,7 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 		});
 
 		//TODO: not sure where it's breaking, but I can't drag to the bottom of the list anymore.
+		// Could maybe cheat and check for if we're on the bottom half of the bottom row and apply a bottom shadow... But this is dumb and bad.
 		row.setOnDragOver(dragEvent -> {
 			Dragboard dragboard = dragEvent.getDragboard();
 			if (dragboard.hasContent(SERIALIZED_MIME_TYPE)) {

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
@@ -15,6 +15,7 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
@@ -26,6 +27,7 @@ import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.*;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.util.Duration;
 import lombok.Getter;
@@ -156,10 +158,6 @@ public class MainWindowView {
 
 	private final ListChangeListener<TableColumn<Mod, ?>> SORT_LISTENER;
 
-	private final double SCROLL_THRESHOLD;
-
-	private final double SCROLL_SPEED;
-
 	private Timeline scrollTimeline;
 
 	private final List<Mod> SELECTIONS;
@@ -178,9 +176,6 @@ public class MainWindowView {
 		SAVE_PROFILES = uiService.getSAVE_PROFILES();
 
 		SERIALIZED_MIME_TYPE = new DataFormat("application/x-java-serialized-object");
-
-		SCROLL_THRESHOLD = 30.0;
-		SCROLL_SPEED = 0.6;
 
 		SELECTIONS = new ArrayList<>();
 
@@ -413,6 +408,10 @@ public class MainWindowView {
 
 	//TODO: Increase speed based on distance from the edge
 	private void handleModTableDragOver(DragEvent event) {
+		//Enables auto-scrolling on the table. When you drag a row above or below the visible rows, the table will automatically start to scroll
+		final double SCROLL_THRESHOLD = 30.0;
+		final double SCROLL_SPEED = 0.7;
+
 		double y = event.getY();
 		double modTableTop = modTable.localToScene(modTable.getBoundsInLocal()).getMinY();
 		double modTableBottom = modTable.localToScene(modTable.getBoundsInLocal()).getMaxY();
@@ -451,7 +450,7 @@ public class MainWindowView {
 						verticalScrollBar.setValue(newValue);
 					})
 			);
-			scrollTimeline.setCycleCount(1); // Keep updating until stopped
+			scrollTimeline.setCycleCount(1); //We only play this for one cycle since we should only be playing the animation when we're actively dragging.
 			scrollTimeline.play(); // Start the scrolling animation
 		}
 

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
@@ -437,10 +437,6 @@ public class MainWindowView {
 			scrollAmount = 0;
 		}
 
-
-		//TODO: We've got a minor bug that, when our window is big enough to display a scrollbar, but it's also big enough to display all the items, when we move our cursor into the gap between the
-		// tableActions pane and table it resizes our columns a little as the bar disappears and then reappears. If you hold it there it'll keep doing it until you drop.
-
 		if (scrollAmount != 0) {
 			if (scrollTimeline == null || !scrollTimeline.getStatus().equals(Animation.Status.RUNNING)) {
 				scrollTimeline = new Timeline(

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MainWindowView.java
@@ -420,23 +420,23 @@ public class MainWindowView {
 		double maxScrollValue = verticalScrollBar.getMax();
 		double scrollAmount;
 
+		//Scroll up
 		if (y < modTableTop + SCROLL_THRESHOLD && currentScrollValue > minScrollValue) {
 			scrollAmount = -SCROLL_SPEED * 0.1; // Increase speed
 		}
-		// Smooth scrolling down
+		//Scroll down
 		else if (y > modTableBottom - SCROLL_THRESHOLD && currentScrollValue < maxScrollValue) {
 			scrollAmount = SCROLL_SPEED * 0.1; // Increase speed
 		} else {
 			scrollAmount = 0;
 		}
 
+		//Stop our timeline if it exists. If we don't call this then the timeline runs forever and the scroll wheel won't work, and probably a bunch of other things.
 		if (scrollTimeline != null) {
 			scrollTimeline.stop();
 		}
 
 		if (scrollAmount != 0) {
-			// Stop any ongoing timeline to prevent multiple timers
-
 			// Create a new Timeline to update the scroll position over time
 			scrollTimeline = new Timeline(
 					new KeyFrame(Duration.millis(30), e -> {  // Increase the duration for smoother transitions. Too high will break it though.

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/ModProfileManagerView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/ModProfileManagerView.java
@@ -66,9 +66,9 @@ public class ModProfileManagerView {
         this.PROFILE_INPUT_VIEW = PROFILE_INPUT_VIEW;
     }
 
-    public void initView(Parent root, Properties properties, MenuBarView mainWindowView) {
+    public void initView(Parent root, Properties properties, MenuBarView menuBarView) {
         Scene scene = new Scene(root);
-        this.menuBarView = mainWindowView;
+        this.menuBarView = menuBarView;
         stage = new Stage();
         stage.initModality(Modality.APPLICATION_MODAL);
 

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/Popup.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/Popup.java
@@ -139,7 +139,7 @@ public class Popup {
 
     //Creates a simple alert centered on a specific stage
     private static void simpleAlert(Stage childStage, Stage parentStage, Label label, FontIcon messageIcon) {
-        HBox dialogBox = makeDialogBoxWithLink(label, messageIcon);
+        HBox dialogBox = makeErrorDialogWithLink(label, messageIcon);
 
         //Setup our button
         HBox buttonBar = makeOkBar(childStage);
@@ -149,7 +149,7 @@ public class Popup {
 
     //Creates a simple alert centered on the screen
     private static void simpleAlert(Stage childStage, Label label, FontIcon messageIcon) {
-        HBox dialogBox = makeDialogBoxWithLink(label, messageIcon);
+        HBox dialogBox = makeErrorDialogWithLink(label, messageIcon);
 
         //Setup our button
         HBox buttonBar = makeOkBar(childStage);
@@ -159,7 +159,7 @@ public class Popup {
 
     //Creates a simple alert centered on the screen, with a clickable link
     private static void simpleAlert(Stage childStage, String message, String link, FontIcon messageIcon) {
-        HBox dialogBox = makeDialogBoxWithLink(message, link, messageIcon);
+        HBox dialogBox = makeErrorDialogWithLink(message, link, messageIcon);
 
         //Setup our button
         HBox buttonBar = makeOkBar(childStage);
@@ -171,7 +171,7 @@ public class Popup {
     private static int yesNoDialog(Stage childStage, Stage parentStage, Label label, FontIcon messageIcon) {
         AtomicInteger choice = new AtomicInteger(-1);
 
-        HBox dialogBox = makeDialogBoxWithLink(label, messageIcon);
+        HBox dialogBox = makeErrorDialogWithLink(label, messageIcon);
 
         HBox buttonBar = makeYesNoBar(choice, childStage);
 
@@ -184,7 +184,7 @@ public class Popup {
     private static int yesNoDialog(Stage childStage, Label label, FontIcon messageIcon) {
         AtomicInteger choice = new AtomicInteger(-1);
 
-        HBox dialogBox = makeDialogBoxWithLink(label, messageIcon);
+        HBox dialogBox = makeErrorDialogWithLink(label, messageIcon);
 
         HBox buttonBar = makeYesNoBar(choice, childStage);
 
@@ -287,7 +287,7 @@ public class Popup {
     }
 
     //Creates a dialog box message
-    private static HBox makeDialogBoxWithLink(Label label, FontIcon messageIcon) {
+    private static HBox makeErrorDialogWithLink(Label label, FontIcon messageIcon) {
         label.setStyle("-fx-font-size: " + FONT_SIZE + ";");
         messageIcon.getStyleClass().clear();
         messageIcon.setIconSize(ICON_SIZE);
@@ -303,7 +303,7 @@ public class Popup {
     }
 
     //Creates a dialog box message, with a hyperlink
-    private static HBox makeDialogBoxWithLink(String message, String link, FontIcon messageIcon) {
+    private static HBox makeErrorDialogWithLink(String message, String link, FontIcon messageIcon) {
         messageIcon.getStyleClass().clear();
         messageIcon.setIconSize(ICON_SIZE);
 
@@ -311,7 +311,7 @@ public class Popup {
         label.setStyle("-fx-font-size: " + FONT_SIZE + ";");
         label.setWrapText(true);
 
-        HBox dialogBox = createLinkBox(link, messageIcon, label);
+        HBox dialogBox = createErrorLinkBox(link, messageIcon, label);
         dialogBox.setAlignment(Pos.TOP_LEFT);
         dialogBox.setPadding(new Insets(0, 5, 0, 5));
         dialogBox.setSpacing(5d);
@@ -320,7 +320,7 @@ public class Popup {
         return dialogBox;
     }
 
-    private static HBox createLinkBox(String link, FontIcon messageIcon, Label label) {
+    private static HBox createErrorLinkBox(String link, FontIcon messageIcon, Label label) {
         Hyperlink hyperlink = new Hyperlink("https://spaceengineersmodmanager.com/bugreport");
         hyperlink.setStyle("-fx-font-size: " + FONT_SIZE + ";");
 

--- a/src/main/resources/view/main-window.fxml
+++ b/src/main/resources/view/main-window.fxml
@@ -47,7 +47,7 @@
                                         </TableView>
                                     </content>
                                 </ScrollPane>
-                                <HBox alignment="CENTER_LEFT" spacing="10.0" VBox.vgrow="NEVER">
+                                <HBox fx:id="tableActions" alignment="CENTER_LEFT" spacing="10.0" VBox.vgrow="NEVER">
                                     <children>
                                         <HBox alignment="CENTER_LEFT" spacing="10.0">
                                             <children>


### PR DESCRIPTION
The mod table will now automatically scroll when you drag a row above or below it, but still within the confines of the stage. It achieves this by manually setting the position of the scrollbar using a timeline to, over time and using interpolation, adjust its position to our desired one. 