### PR TITLE
Migrated center content for MainWindow to discrete classes

### DIFF
--- a/src/main/java/com/gearshiftgaming/se_mod_manager/controller/ViewController.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/controller/ViewController.java
@@ -15,6 +15,7 @@ import jakarta.xml.bind.JAXBException;
 import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.stage.Stage;
@@ -107,61 +108,67 @@ public class ViewController {
 		//For the constructors for each view, they need to have a value for whatever views that will be the "child" of that view, ie, they are only accessible in the UI through that view. Think of it as a hierarchical structure.
 
 		//View for adding a new Save Profile
-		FXMLLoader saveListInputLoader = new FXMLLoader(getClass().getResource("/view/save-list-input.fxml"));
-		SaveInputView saveInputView = new SaveInputView(UI_SERVICE);
-		saveListInputLoader.setController(saveInputView);
-		Parent saveListInputRoot = saveListInputLoader.load();
-		saveInputView.initView(saveListInputRoot);
+		final FXMLLoader SAVE_LIST_INPUT_LOADER = new FXMLLoader(getClass().getResource("/view/save-list-input.fxml"));
+		final SaveInputView SAVE_INPUT_VIEW = new SaveInputView(UI_SERVICE);
+		SAVE_LIST_INPUT_LOADER.setController(SAVE_INPUT_VIEW);
+		final Parent SAVE_LIST_INPUT_ROOT = SAVE_LIST_INPUT_LOADER.load();
+		SAVE_INPUT_VIEW.initView(SAVE_LIST_INPUT_ROOT);
 
 		//View for text input when creating a new save profile.
-		FXMLLoader saveProfileManagerLoader = new FXMLLoader(getClass().getResource("/view/profile-input.fxml"));
-		ProfileInputView saveProfileInputView = new ProfileInputView();
-		saveProfileManagerLoader.setController(saveProfileInputView);
-		Parent saveListInputSecondStepRoot = saveProfileManagerLoader.load();
-		saveProfileInputView.initView(saveListInputSecondStepRoot);
+		final FXMLLoader SAVE_PROFILE_MANAGER_LOADER = new FXMLLoader(getClass().getResource("/view/profile-input.fxml"));
+		final ProfileInputView SAVE_PROFILE_INPUT_VIEW = new ProfileInputView();
+		SAVE_PROFILE_MANAGER_LOADER.setController(SAVE_PROFILE_INPUT_VIEW);
+		final Parent SAVE_PROFILE_MANAGER_ROOT = SAVE_PROFILE_MANAGER_LOADER.load();
+		SAVE_PROFILE_INPUT_VIEW.initView(SAVE_PROFILE_MANAGER_ROOT);
 
 		//View for text input when adding a new Mod Profile
-		FXMLLoader modProfileManagerLoader = new FXMLLoader(getClass().getResource("/view/profile-input.fxml"));
-		ProfileInputView modProfileInputView = new ProfileInputView();
-		modProfileManagerLoader.setController(modProfileInputView);
-		Parent modProfileCreateRoot = modProfileManagerLoader.load();
-		modProfileInputView.initView(modProfileCreateRoot);
+		final FXMLLoader MOD_PROFILE_INPUT_LOADER = new FXMLLoader(getClass().getResource("/view/profile-input.fxml"));
+		final ProfileInputView MOD_PROFILE_INPUT_VIEW = new ProfileInputView();
+		MOD_PROFILE_INPUT_LOADER.setController(MOD_PROFILE_INPUT_VIEW);
+		final Parent MOD_PROFILE_INPUT_ROOT = MOD_PROFILE_INPUT_LOADER.load();
+		MOD_PROFILE_INPUT_VIEW.initView(MOD_PROFILE_INPUT_ROOT);
 
 		//View for managing Save Profiles
-		FXMLLoader saveManagerLoader = new FXMLLoader(getClass().getResource("/view/save-profile-manager.fxml"));
-		SaveManagerView saveManagerView = new SaveManagerView(UI_SERVICE, saveInputView, saveProfileInputView);
-		saveManagerLoader.setController(saveManagerView);
-		Parent saveManagerRoot = saveManagerLoader.load();
+		final FXMLLoader SAVE_MANAGER_LOADER = new FXMLLoader(getClass().getResource("/view/save-profile-manager.fxml"));
+		final SaveManagerView SAVE_MANAGER_VIEW = new SaveManagerView(UI_SERVICE, SAVE_INPUT_VIEW, SAVE_PROFILE_INPUT_VIEW);
+		SAVE_MANAGER_LOADER.setController(SAVE_MANAGER_VIEW);
+		final Parent SAVE_MANAGER_ROOT = SAVE_MANAGER_LOADER.load();
 
 		//View for managing Mod Profiles
-		FXMLLoader modProfilerManagerLoader = new FXMLLoader(getClass().getResource("/view/mod-profile-manager.fxml"));
-		ModProfileManagerView modProfileManagerView = new ModProfileManagerView(UI_SERVICE, modProfileInputView);
-		modProfilerManagerLoader.setController(modProfileManagerView);
-		Parent modProfileRoot = modProfilerManagerLoader.load();
-
-		//View for the menubar section of the main window
-		FXMLLoader menuBarLoader = new FXMLLoader(getClass().getResource("/view/menubar.fxml"));
-		MenuBarView menuBarView = new MenuBarView(UI_SERVICE, modProfileManagerView, saveManagerView);
-		menuBarLoader.setController(menuBarView);
-		Parent menuBarRoot = menuBarLoader.load();
+		final FXMLLoader MOD_PROFILE_MANAGER_LOADER = new FXMLLoader(getClass().getResource("/view/mod-profile-manager.fxml"));
+		final ModProfileManagerView MOD_PROFILE_MANAGER_VIEW = new ModProfileManagerView(UI_SERVICE, MOD_PROFILE_INPUT_VIEW);
+		MOD_PROFILE_MANAGER_LOADER.setController(MOD_PROFILE_MANAGER_VIEW);
+		final Parent MOD_PROFILE_MANAGER_ROOT = MOD_PROFILE_MANAGER_LOADER.load();
 
 		//View for the statusbar section of the main window
-		FXMLLoader statusBarLoader = new FXMLLoader(getClass().getResource("/view/statusbar.fxml"));
-		StatusBarView statusBarView = new StatusBarView(UI_SERVICE);
-		statusBarLoader.setController(statusBarView);
-		Parent statusBarRoot = statusBarLoader.load();
+		final FXMLLoader STATUS_BAR_LOADER = new FXMLLoader(getClass().getResource("/view/statusbar.fxml"));
+		final StatusBarView STATUS_BAR_VIEW = new StatusBarView(UI_SERVICE);
+		STATUS_BAR_LOADER.setController(STATUS_BAR_VIEW);
+		final Parent STATUS_BAR_ROOT = STATUS_BAR_LOADER.load();
 
-		//View for the primary application window
-		FXMLLoader mainViewLoader = new FXMLLoader(getClass().getResource("/view/main-window.fxml"));
-		MainWindowView mainWindowView = new MainWindowView(PROPERTIES, stage,
-				menuBarView, statusBarView, UI_SERVICE);
-		mainViewLoader.setController(mainWindowView);
-		Parent mainViewRoot = mainViewLoader.load();
-		mainWindowView.initView(mainViewRoot, menuBarRoot, statusBarRoot);
+		//View for managing the actual mod lists. This is the center section of the main window
+		final FXMLLoader MODLIST_MANAGER_LOADER = new FXMLLoader(getClass().getResource("/view/modlist-manager.fxml"));
+		final ModlistManagerView MODLIST_MANAGER_VIEW = new ModlistManagerView(UI_SERVICE, STATUS_BAR_VIEW);
+		MODLIST_MANAGER_LOADER.setController(MODLIST_MANAGER_VIEW);
+		final Parent MODLIST_MANAGER_ROOT = MODLIST_MANAGER_LOADER.load();
+
+		//View for the menubar section of the main window
+		final FXMLLoader MENU_BAR_LOADER = new FXMLLoader(getClass().getResource("/view/menubar.fxml"));
+		final MenuBarView MENU_BAR_VIEW = new MenuBarView(UI_SERVICE, MOD_PROFILE_MANAGER_VIEW, SAVE_MANAGER_VIEW, MODLIST_MANAGER_VIEW);
+		MENU_BAR_LOADER.setController(MENU_BAR_VIEW);
+		final Parent MENU_BAR_ROOT = MENU_BAR_LOADER.load();
 
 		//The mod and save manager are fully initialized down here as we only have all the references we need at this stage
-		modProfileManagerView.initView(modProfileRoot, PROPERTIES, menuBarView);
-		saveManagerView.initView(saveManagerRoot, PROPERTIES, menuBarView);
+		MOD_PROFILE_MANAGER_VIEW.initView(MOD_PROFILE_MANAGER_ROOT, PROPERTIES, MENU_BAR_VIEW);
+		SAVE_MANAGER_VIEW.initView(SAVE_MANAGER_ROOT, PROPERTIES, MENU_BAR_VIEW);
+
+		//View for the primary application window
+		final FXMLLoader MAIN_VIEW_LOADER = new FXMLLoader(getClass().getResource("/view/main-window.fxml"));
+		final MainWindowView MAIN_WINDOW_VIEW = new MainWindowView(PROPERTIES, stage,
+				MENU_BAR_VIEW, MODLIST_MANAGER_VIEW, STATUS_BAR_VIEW, UI_SERVICE);
+		MAIN_VIEW_LOADER.setController(MAIN_WINDOW_VIEW);
+		final Parent MAIN_VIEW_ROOT = MAIN_VIEW_LOADER.load();
+		MAIN_WINDOW_VIEW.initView(MAIN_VIEW_ROOT, MENU_BAR_ROOT, MODLIST_MANAGER_ROOT, STATUS_BAR_ROOT);
 
 		//Save our changes that were made to the user config, such as removing missing profiles, to disk
 		UI_SERVICE.saveUserData();

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MenuBarView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MenuBarView.java
@@ -29,8 +29,6 @@ import java.util.List;
  * this file. If not, please write to: gearshift@gearshiftgaming.com.
 
  */
-
-@Getter
 public class MenuBarView {
 
 	//FXML Items
@@ -38,9 +36,11 @@ public class MenuBarView {
 	private MenuItem saveModlistAs;
 
 	@FXML
+	@Getter
 	private CheckMenuItem logToggle;
 
 	@FXML
+	@Getter
 	private CheckMenuItem modDescriptionToggle;
 
 	@FXML
@@ -65,19 +65,23 @@ public class MenuBarView {
 	private MenuItem manageSaveProfiles;
 
 	@FXML
+	@Getter
 	private ComboBox<ModProfile> modProfileDropdown;
 
 	@FXML
+	@Getter
 	private ComboBox<SaveProfile> saveProfileDropdown;
 
 	@FXML
+	@Getter
 	private Text activeModCount;
 
 	@FXML
+	@Getter
 	private Text modConflicts;
 
 	@FXML
-	private TextField modTableSearchBox;
+	private TextField modTableSearchField;
 
 	@FXML
 	private Button clearSearchBox;
@@ -103,15 +107,12 @@ public class MenuBarView {
 	@FXML
 	private CheckMenuItem draculaTheme;
 
-	private MainWindowView mainWindowView;
+	//TODO: Should replace this with a ModlistManagerView
+	private final ModlistManagerView MODLIST_MANAGER_VIEW;
 
 	private final List<CheckMenuItem> THEME_LIST = new ArrayList<>();
 
 	private final UiService UI_SERVICE;
-
-	private final ObservableList<ModProfile> MOD_PROFILES;
-
-	private final ObservableList<SaveProfile> SAVE_PROFILES;
 
 	private final ModProfileManagerView MOD_PROFILE_MANAGER_VIEW;
 
@@ -119,7 +120,7 @@ public class MenuBarView {
 
 	//TODO: On dropdown select, change active profile
 
-	public MenuBarView(UiService UI_SERVICE, ModProfileManagerView MOD_PROFILE_MANAGER_VIEW, SaveManagerView SAVE_MANAGER_VIEW) throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+	public MenuBarView(UiService uiService, ModProfileManagerView modProfileManagerView, SaveManagerView saveManagerView, ModlistManagerView modlistManagerView) throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
 		//FIXME: For some reason a tiny section of the saveProfileDropdown isn't highlighted blue when selected. It's an issue with the button cell.
 		// - For some reason, calling:
 		//		ListCell<SaveProfile> buttonCellFix = new SaveProfileCell();
@@ -127,16 +128,13 @@ public class MenuBarView {
 		//		buttonCellFix.setText(saveProfile.getProfileName());
 		//		topBarView.getSaveProfileDropdown().setButtonCell(buttonCellFix);
 		//	in saveManagerView fixes it?! WHY?!
-		this.UI_SERVICE = UI_SERVICE;
-		this.MOD_PROFILE_MANAGER_VIEW = MOD_PROFILE_MANAGER_VIEW;
-		this.SAVE_MANAGER_VIEW = SAVE_MANAGER_VIEW;
-
-		MOD_PROFILES = UI_SERVICE.getMOD_PROFILES();
-		SAVE_PROFILES = UI_SERVICE.getSAVE_PROFILES();
+		this.UI_SERVICE = uiService;
+		this.MOD_PROFILE_MANAGER_VIEW = modProfileManagerView;
+		this.SAVE_MANAGER_VIEW = saveManagerView;
+		this.MODLIST_MANAGER_VIEW = modlistManagerView;
 	}
 
-	public void initView(MainWindowView mainWindowView) throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
-		this.mainWindowView = mainWindowView;
+	public void initView() throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
 
 		THEME_LIST.add(primerLightTheme);
 		THEME_LIST.add(primerDarkTheme);
@@ -152,7 +150,7 @@ public class MenuBarView {
 		saveProfileDropdown.setCellFactory(param -> new SaveProfileCell());
 		saveProfileDropdown.setButtonCell(new SaveProfileCell());
 
-		modProfileDropdown.setItems(MOD_PROFILES);
+		modProfileDropdown.setItems(UI_SERVICE.getMOD_PROFILES());
 		modProfileDropdown.getSelectionModel().selectFirst();
 
 		UI_SERVICE.setUserSavedApplicationTheme(THEME_LIST);
@@ -186,32 +184,33 @@ public class MenuBarView {
 
 	@FXML
 	private void toggleLog() {
-		TabPane informationPane = mainWindowView.getInformationPane();
-		Tab logTab = mainWindowView.getLogTab();
+		TabPane informationPane = MODLIST_MANAGER_VIEW.getInformationPane();
+		Tab logTab = MODLIST_MANAGER_VIEW.getLogTab();
 
 		if (!logToggle.isSelected()) {
 			informationPane.getTabs().remove(logTab);
 		} else informationPane.getTabs().add(logTab);
 
 		if (informationPane.getTabs().isEmpty()) {
-			mainWindowView.disableSplitPaneDivider();
-		} else if (!mainWindowView.isMainViewSplitDividerVisible()) {
-			mainWindowView.enableSplitPaneDivider();
+			MODLIST_MANAGER_VIEW.disableSplitPaneDivider();
+		} else if (!MODLIST_MANAGER_VIEW.isMainViewSplitDividerVisible()) {
+			MODLIST_MANAGER_VIEW.enableSplitPaneDivider();
 		}
 	}
 
 	@FXML
 	private void toggleModDescription() {
-		TabPane informationPane = mainWindowView.getInformationPane();
-		Tab modDescriptionTab = mainWindowView.getModDescriptionTab();
+		TabPane informationPane = MODLIST_MANAGER_VIEW.getInformationPane();
+		Tab modDescriptionTab = MODLIST_MANAGER_VIEW.getModDescriptionTab();
+
 		if (!modDescriptionToggle.isSelected()) {
 			informationPane.getTabs().remove(modDescriptionTab);
 		} else informationPane.getTabs().add(modDescriptionTab);
 
 		if (informationPane.getTabs().isEmpty()) {
-			mainWindowView.disableSplitPaneDivider();
-		} else if (!mainWindowView.isMainViewSplitDividerVisible()) {
-			mainWindowView.enableSplitPaneDivider();
+			MODLIST_MANAGER_VIEW.disableSplitPaneDivider();
+		} else if (!MODLIST_MANAGER_VIEW.isMainViewSplitDividerVisible()) {
+			MODLIST_MANAGER_VIEW.enableSplitPaneDivider();
 		}
 	}
 
@@ -243,7 +242,7 @@ public class MenuBarView {
 
 		Result<Void> savedUserTheme = UI_SERVICE.saveUserData();
 		//This fixes the selected row being the wrong color until we change selection
-		mainWindowView.getModTable().refresh();
+		MODLIST_MANAGER_VIEW.getModTable().refresh();
 		if (savedUserTheme.isSuccess()) {
 			UI_SERVICE.log("Successfully set user theme to " + selectedTheme + ".", MessageType.INFO);
 		} else {
@@ -265,7 +264,7 @@ public class MenuBarView {
 	private void selectModProfile() {
 		ModProfile modProfile = modProfileDropdown.getSelectionModel().getSelectedItem();
 		UI_SERVICE.setCurrentModProfile(modProfile);
-		mainWindowView.getModTable().setItems(UI_SERVICE.getCurrentModList());
+		MODLIST_MANAGER_VIEW.getModTable().setItems(UI_SERVICE.getCurrentModList());
 		//TODO: Update the mod table. Wrap the modlist in the profile with an observable list!
 	}
 
@@ -277,6 +276,6 @@ public class MenuBarView {
 
 	@FXML
 	private void clearSearchBox() {
-		modTableSearchBox.clear();
+		modTableSearchField.clear();
 	}
 }

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/ModlistManagerView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/ModlistManagerView.java
@@ -1,0 +1,435 @@
+package com.gearshiftgaming.se_mod_manager.frontend.view;
+
+import com.gearshiftgaming.se_mod_manager.backend.models.Mod;
+import com.gearshiftgaming.se_mod_manager.backend.models.ModProfile;
+import com.gearshiftgaming.se_mod_manager.backend.models.ModType;
+import com.gearshiftgaming.se_mod_manager.backend.models.SaveProfile;
+import com.gearshiftgaming.se_mod_manager.backend.models.utility.LogMessage;
+import com.gearshiftgaming.se_mod_manager.frontend.domain.UiService;
+import com.gearshiftgaming.se_mod_manager.frontend.models.LogCell;
+import com.gearshiftgaming.se_mod_manager.frontend.models.ModNameCell;
+import com.gearshiftgaming.se_mod_manager.frontend.models.ModTableRowFactory;
+import javafx.animation.Animation;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.Node;
+import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.input.DataFormat;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.HBox;
+import javafx.scene.text.Text;
+import javafx.util.Duration;
+import lombok.Getter;
+
+import java.awt.*;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/** Copyright (C) 2024 Gear Shift Gaming - All Rights Reserved
+ * You may use, distribute, and modify this code under the terms of the GPL3 license.
+ * <p>
+ * You should have received a copy of the GPL3 license with
+ * this file. If not, please write to: gearshift@gearshiftgaming.com.
+ */
+public class ModlistManagerView {
+	@FXML
+	private ComboBox<String> modImportDropdown;
+
+	@FXML
+	private Button importModlist;
+
+	@FXML
+	private Button exportModlist;
+
+	@FXML
+	private Button resetModlist;
+
+	@FXML
+	private Button injectModlist;
+
+	@FXML
+	private Button launchSpaceEngineers;
+
+	@FXML
+	@Getter
+	private SplitPane mainViewSplit;
+
+	//TODO: Low priority: Fix the alignment of the table headers to be centered, not center left.
+	@FXML
+	@Getter
+	private TableView<Mod> modTable;
+
+	@FXML
+	private TableColumn<Mod, Mod> modName;
+
+	@FXML
+	private TableColumn<Mod, String> modType;
+
+	@FXML
+	private TableColumn<Mod, String> modVersion;
+
+	@FXML
+	private TableColumn<Mod, String> modLastUpdated;
+
+	@FXML
+	private TableColumn<Mod, Integer> loadPriority;
+
+	@FXML
+	private TableColumn<Mod, String> modSource;
+
+	@FXML
+	private TableColumn<Mod, String> modCategory;
+
+	@FXML
+	private HBox tableActions;
+
+	@FXML
+	@Getter
+	private TabPane informationPane;
+
+	@FXML
+	@Getter
+	private Tab logTab;
+
+	@FXML
+	@Getter
+	private Tab modDescriptionTab;
+
+	@FXML
+	private ListView<LogMessage> viewableLog;
+
+	private final UiService UI_SERVICE;
+
+	private final ObservableList<LogMessage> USER_LOG;
+
+	@Getter
+	private boolean mainViewSplitDividerVisible = true;
+
+	//This is just a wrapper for the userConfiguration modProfiles list. Any changes made to this will propagate back to it, but not the other way around.
+	private final ObservableList<ModProfile> MOD_PROFILES;
+
+	//This is just a wrapper for the userConfiguration saveProfiles list. Any changes made to this will propagate back to it, but not the other way around.
+	private final ObservableList<SaveProfile> SAVE_PROFILES;
+
+	private final DataFormat SERIALIZED_MIME_TYPE;
+
+	private ListChangeListener<TableColumn<Mod, ?>> sortListener;
+
+	private Timeline scrollTimeline;
+
+	private final List<Mod> SELECTIONS;
+
+	//This list existing is a really, really dumb hack because it's impossible to get the actual row height from the table otherwise.
+	//It should only ever have one item.
+	private final List<TableRow<Mod>> SINGLE_TABLE_ROW;
+
+	//TODO: We might not need this if we setup a listener properly on the active mod count, but I'm not sure how we can since it has to be done in ModNameCell.
+	private Text activeModCount;
+
+	//TODO: We might not need this if we setup a listener properly on the active mod count, but I'm not sure how we can since it has to be done in ModNameCell.
+	private Text modConflicts;
+
+	private CheckMenuItem logToggle;
+
+	private CheckMenuItem modDescriptionToggle;
+
+	//This is the reference to the controller for the bar located in the bottom section of the main borderpane. We need everything in it so might as well get the whole reference.
+	private final StatusBarView STATUS_BAR_VIEW;
+
+	public ModlistManagerView(UiService uiService, StatusBarView statusBarView) {
+		this.UI_SERVICE = uiService;
+		this.MOD_PROFILES = uiService.getMOD_PROFILES();
+		this.SAVE_PROFILES = uiService.getSAVE_PROFILES();
+		this.USER_LOG = uiService.getUSER_LOG();
+		this.STATUS_BAR_VIEW = statusBarView;
+
+		SERIALIZED_MIME_TYPE = new DataFormat("application/x-java-serialized-object");
+		SELECTIONS = new ArrayList<>();
+		SINGLE_TABLE_ROW = new ArrayList<>();
+	}
+
+	public void initView(Text activeModCount, Text modConflicts, CheckMenuItem logToggle, CheckMenuItem modDescriptionToggle) {
+		this.activeModCount = activeModCount;
+		this.modConflicts = modConflicts;
+		this.logToggle = logToggle;
+		this.modDescriptionToggle = modDescriptionToggle;
+
+		sortListener = change -> {
+			if (modTable.getSortOrder().isEmpty()) {
+				applyDefaultSort();
+			}
+		};
+
+		setupMainViewItems();
+		setupModTable();
+		tableActions.setOnDragDropped(this::handleTableActionsDragOver);
+	}
+
+	//TODO: If our mod profile is null but we make a save, popup mod profile UI too. And vice versa for save profile.
+	//TODO: Allow for adding/removing columns. Add a context menu to the column header.
+	private void setupModTable() {
+
+		modTable.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+		modTable.setRowFactory(new ModTableRowFactory(UI_SERVICE, SERIALIZED_MIME_TYPE, SELECTIONS, SINGLE_TABLE_ROW));
+
+		modName.setCellValueFactory(cellData -> new ReadOnlyObjectWrapper<>(cellData.getValue()));
+		modName.setCellFactory(param -> new ModNameCell(UI_SERVICE));
+		modName.setComparator(Comparator.comparing(Mod::getFriendlyName));
+
+		//Format the appearance, styling, and menu`s of our table cells, rows, and columns
+		modVersion.setCellValueFactory(cellData -> new SimpleStringProperty(cellData.getValue().getModVersion()));
+		modLastUpdated.setCellValueFactory(cellData -> new SimpleStringProperty(cellData.getValue().getLastUpdated() != null ?
+				cellData.getValue().getLastUpdated().toString() : "Unknown"));
+
+		loadPriority.setCellValueFactory(cellData -> new SimpleIntegerProperty(cellData.getValue().getLoadPriority()).asObject());
+
+		modType.setCellValueFactory(cellData -> new SimpleStringProperty((cellData.getValue().getModType().equals(ModType.STEAM) ? "Steam" : "Mod.io")));
+		modCategory.setCellValueFactory(cellData -> {
+			StringBuilder sb = new StringBuilder();
+			List<String> categories = cellData.getValue().getCategories();
+			for (int i = 0; i < cellData.getValue().getCategories().size(); i++) {
+				if (i + 1 < cellData.getValue().getCategories().size()) {
+					sb.append(categories.get(i)).append(", ");
+				} else {
+					sb.append(categories.get(i));
+				}
+			}
+			return new SimpleStringProperty(sb.toString());
+		});
+
+		modTable.getSortOrder().addListener(sortListener);
+		modTable.setItems(UI_SERVICE.getCurrentModList());
+	}
+
+
+	//TODO: Make it so that when we change the modlist and save it, but don't inject it, the status becomes "Modified since last injection"
+	//TODO: Set a limit on the modprofile and saveprofile maximum sizes that's reasonable. If they're too large they messup the appearance of the prompt text for the search bar.
+	public void setupMainViewItems() {
+		viewableLog.setItems(USER_LOG);
+		viewableLog.setCellFactory(param -> new LogCell());
+		//Disable selecting rows in the log.
+		viewableLog.setSelectionModel(null);
+
+		modImportDropdown.getItems().addAll("Add mods by Steam Workshop ID", "Add mods from Steam Collection", "Add mods from Mod.io", "Add mods from modlist file");
+
+		//TODO: Setup a function in ModList service to track conflicts.
+	}
+	//TODO: Hookup all the buttons to everything
+
+	@FXML
+	private void closeLogTab() {
+		logToggle.setSelected(false);
+		if (informationPane.getTabs().isEmpty()) {
+			disableSplitPaneDivider();
+		}
+	}
+
+	@FXML
+	private void closeModDescriptionTab() {
+		modDescriptionToggle.setSelected(false);
+		if (informationPane.getTabs().isEmpty()) {
+			disableSplitPaneDivider();
+		}
+	}
+
+	private void importModlist() {
+		//TODO: Implement. Allow importing modlists from either sandbox file or exported list.
+	}
+
+	@FXML
+	private void exportModlist() {
+		//TODO: Implement. Export in our own format (use XML).
+	}
+
+	@FXML
+	private void resetModlist() {
+		//TODO: Implement by setting the current modprofile modlist to whatever it is in our user configuration.
+		// Make a popup asking if they're sure they want to reset the modlist.
+		// Also make a popup if the list was never saved and can't be found in the user configuration.
+	}
+
+	//Apply the modlist the user is currently using to the save profile they're currently using.
+	//TODO: This whole thing likely need rewritten
+	@FXML
+	private void applyModlist() throws IOException {
+//		SaveProfile currentSaveProfile = uiService.getCurrentSaveProfile();
+//		ModProfile currentModProfile = uiService.getCurrentModProfile();
+//		//This should only return null when the SEMM has been run for the first time and the user hasn't made and modlists or save profiles.
+//		if (currentSaveProfile != null && currentModProfile != null && currentSaveProfile.getSavePath() != null) {
+//			//TODO: Have a warning popup asking the user if they want to continue IF they have a mod profile that contains no mods.
+//			Result<Void> modlistResult = uiService.applyModlist(currentModProfile.getModList(), currentSaveProfile.getSavePath());
+//			uiService.log(modlistResult);
+//			if (!modlistResult.isSuccess()) {
+//				currentSaveProfile.setLastSaveStatus(SaveStatus.FAILED);
+//			} else {
+//				currentSaveProfile.setLastAppliedModProfileId(currentModProfile.getId());
+//
+//				//TODO: This and the currentSave profile are both null, but they aren't actually. Why? This logic probably needs all looked over and rewritten.
+//				int modProfileIndex = modProfiles.indexOf(currentModProfile);
+//				modProfiles.set(modProfileIndex, currentModProfile);
+//
+//				int saveProfileIndex = saveProfiles.indexOf(currentSaveProfile);
+//				saveProfiles.set(saveProfileIndex, currentSaveProfile);
+//
+//				uiService.log(uiService.saveUserData(userConfiguration));
+//				currentSaveProfile.setLastSaveStatus(SaveStatus.SAVED);
+//			}
+//			statusBarView.update(currentSaveProfile);
+//		} else {
+//			//Save or Mod profile not setup yet. Create both a Save and Mod profile to be able to apply a modlist.
+//			String errorMessage = "Save profile not setup yet. Create a save profile to apply a modlist.";
+//			uiService.log(errorMessage, MessageType.ERROR);
+//			Popup.displaySimpleAlert(errorMessage, stage, MessageType.ERROR);
+//		}
+	}
+
+	@FXML
+	private void launchSpaceEngineers() throws URISyntaxException, IOException {
+		//TODO: Check this works on systems with no previous steam url association
+		Desktop.getDesktop().browse(new URI("steam://rungameid/244850"));
+	}
+
+	protected void disableSplitPaneDivider() {
+		for (Node node : mainViewSplit.lookupAll(".split-pane-divider")) {
+			node.setVisible(false);
+			mainViewSplitDividerVisible = false;
+		}
+		mainViewSplit.setDividerPosition(0, 1);
+	}
+
+	protected void enableSplitPaneDivider() {
+		for (Node node : mainViewSplit.lookupAll(".split-pane-divider")) {
+			node.setVisible(true);
+			mainViewSplitDividerVisible = true;
+		}
+		mainViewSplit.setDividerPosition(0, 0.7);
+	}
+
+	private void applyDefaultSort() {
+		if (loadPriority != null) {
+			modTable.getSortOrder().removeListener(sortListener);
+
+			loadPriority.setSortType(TableColumn.SortType.ASCENDING);
+			modTable.getSortOrder().add(loadPriority);
+			modTable.sort();
+			modTable.getSortOrder().clear();
+
+			modTable.getSortOrder().addListener(sortListener);
+		}
+	}
+
+	//TODO: Increase speed based on distance from the edge
+	protected void handleModTableDragOver(DragEvent event) {
+		//Enables auto-scrolling on the table. When you drag a row above or below the visible rows, the table will automatically start to scroll
+		final double SCROLL_THRESHOLD = 20.0;
+		final double SCROLL_SPEED = 0.3;
+
+		double y = event.getY();
+		double modTableTop = modTable.localToScene(modTable.getBoundsInLocal()).getMinY();
+		double modTableBottom = modTable.localToScene(modTable.getBoundsInLocal()).getMaxY();
+
+		ScrollBar verticalScrollBar = (ScrollBar) modTable.lookup(".scroll-bar:vertical");
+
+		double currentScrollValue = verticalScrollBar.getValue();
+		double minScrollValue = verticalScrollBar.getMin();
+		double maxScrollValue = verticalScrollBar.getMax();
+		double scrollAmount;
+
+		//Scroll up
+		if (y < modTableTop - SCROLL_THRESHOLD && currentScrollValue > minScrollValue && modTable.getItems().size() * SINGLE_TABLE_ROW.getFirst().getHeight() > modTable.getHeight()) {
+			scrollAmount = -SCROLL_SPEED * 0.1;
+		} else if (y > modTableBottom + SCROLL_THRESHOLD && currentScrollValue < maxScrollValue && modTable.getItems().size() * SINGLE_TABLE_ROW.getFirst().getHeight() > modTable.getHeight()) {
+			scrollAmount = SCROLL_SPEED * 0.1;
+		} else {
+			scrollAmount = 0;
+		}
+
+		if (scrollAmount != 0) {
+			if (scrollTimeline == null || !scrollTimeline.getStatus().equals(Animation.Status.RUNNING)) {
+				scrollTimeline = new Timeline(
+						new KeyFrame(Duration.millis(16), e -> { // 1000ms in a second, so we need 16ms here for a 60fps animation
+							double newValue = verticalScrollBar.getValue() + scrollAmount;
+							newValue = Math.max(minScrollValue, Math.min(maxScrollValue, newValue)); // Clamp the value
+							verticalScrollBar.setValue(newValue);
+						})
+				);
+				scrollTimeline.setCycleCount(60); //One second of animation is 60 cycles, so set this to 60 so we don't end up with infinite animations.
+				scrollTimeline.play(); // Start the scrolling animation
+			}
+		} else {
+			if (scrollTimeline != null) {
+				scrollTimeline.stop();
+			}
+		}
+
+		event.acceptTransferModes(TransferMode.MOVE);
+		event.consume();
+	}
+
+	//This ensures that we properly allow dragging items to the bottom of the table even when we have a scrollable table.
+	private void handleTableActionsDragOver(DragEvent dragEvent) {
+		Dragboard dragboard = dragEvent.getDragboard();
+
+		if (dragboard.hasContent(SERIALIZED_MIME_TYPE)) {
+
+			for (Mod m : SELECTIONS) {
+				modTable.getItems().remove(m);
+			}
+
+			modTable.getSelectionModel().clearSelection();
+
+			for (Mod m : SELECTIONS) {
+				modTable.getItems().add(m);
+				modTable.getSelectionModel().select(modTable.getItems().size() - 1);
+			}
+
+			//TODO: Need to move the duplicates to a shared helper class. Call it "tableHelper" or something.
+			if (modTable.getSortOrder().isEmpty() || modTable.getSortOrder().getFirst().getSortType().equals(TableColumn.SortType.ASCENDING)) {
+				for (int i = 0; i < UI_SERVICE.getCurrentModProfile().getModList().size(); i++) {
+					UI_SERVICE.getCurrentModList().get(i).setLoadPriority(i + 1);
+				}
+			} else {
+				for (int i = 0; i < UI_SERVICE.getCurrentModProfile().getModList().size(); i++) {
+					UI_SERVICE.getCurrentModList().get(i).setLoadPriority(getIntendedLoadPriority(modTable, i));
+				}
+			}
+
+			//Redo our sort since our row order has changed
+			modTable.sort();
+
+			/*
+				We shouldn't need this since currentModList which backs our table is an observable list backed by the currentModProfile.getModList,
+				but for whatever reason the changes aren't propagating without this.
+			*/
+			//TODO: Look into why the changes don't propagate without setting it here. Indicative of a deeper issue or misunderstanding.
+			UI_SERVICE.getCurrentModProfile().setModList(UI_SERVICE.getCurrentModList());
+			UI_SERVICE.saveUserData();
+
+			dragEvent.consume();
+		}
+	}
+
+	private int getIntendedLoadPriority(TableView<Mod> modTable, int index) {
+		int intendedLoadPriority;
+		//Check if we are in ascending/default order, else we're in descending order
+		if (modTable.getSortOrder().isEmpty() || modTable.getSortOrder().getFirst().getSortType().equals(TableColumn.SortType.ASCENDING)) {
+			return index;
+		} else {
+			intendedLoadPriority = UI_SERVICE.getCurrentModList().size() - index;
+		}
+		return intendedLoadPriority;
+	}
+}

--- a/src/main/resources/view/main-window.fxml
+++ b/src/main/resources/view/main-window.fxml
@@ -1,103 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ButtonBar?>
-<?import javafx.scene.control.ComboBox?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.ListView?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.SplitPane?>
-<?import javafx.scene.control.Tab?>
-<?import javafx.scene.control.TabPane?>
-<?import javafx.scene.control.TableColumn?>
-<?import javafx.scene.control.TableView?>
-<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
 
-<AnchorPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="1050.0" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="1050.0"
+            xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
     <children>
-        <BorderPane fx:id="mainWindowLayout" layoutY="27.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-            <center>
-                <SplitPane fx:id="mainViewSplit" dividerPositions="0.7" orientation="VERTICAL" BorderPane.alignment="CENTER">
-                    <items>
-                        <VBox>
-                            <children>
-                                <ScrollPane fitToHeight="true" fitToWidth="true" VBox.vgrow="ALWAYS">
-                                    <content>
-                                        <TableView fx:id="modTable" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
-                                            <placeholder>
-                                                <Label text="No Mods Installed" />
-                                            </placeholder>
-                                            <columns>
-                                                <TableColumn fx:id="modName" prefWidth="200.0" text="Mod Name" />
-                                                <TableColumn fx:id="loadPriority" prefWidth="85.0" text="Priority" />
-                                                <TableColumn fx:id="modLastUpdated" prefWidth="115.0" text="Last Updated" />
-                                                <TableColumn fx:id="modVersion" prefWidth="85.0" text="Version" />
-                                                <TableColumn fx:id="modSource" prefWidth="85.0" text="Import Source" visible="false" />
-                                                <TableColumn fx:id="modType" prefWidth="100.0" text="Source" />
-                                                <TableColumn fx:id="modCategory" prefWidth="125.0" text="Category/Tags" />
-                                            </columns>
-                                            <columnResizePolicy>
-                                                <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                                            </columnResizePolicy>
-                                        </TableView>
-                                    </content>
-                                </ScrollPane>
-                                <HBox fx:id="tableActions" alignment="CENTER_LEFT" spacing="10.0" VBox.vgrow="NEVER">
-                                    <children>
-                                        <HBox alignment="CENTER_LEFT" spacing="10.0">
-                                            <children>
-                                                <ComboBox fx:id="modImportDropdown" prefWidth="250.0" promptText="Add mods from..." />
-                                            </children>
-                                        </HBox>
-                                        <ButtonBar buttonOrder="U+FBIX_NCYOA_R">
-                                            <buttons>
-                                                <Button fx:id="importModlist" mnemonicParsing="false" text="Import Modlist" />
-                                                <Button fx:id="exportModlist" mnemonicParsing="false" text="Export Modlist" />
-                                                <Button fx:id="resetModlist" mnemonicParsing="false" text="Reset Modlist" />
-                                                <Button fx:id="injectModlist" mnemonicParsing="false" onAction="#applyModlist" text="Apply Modlist" />
-                                                <Button fx:id="launchSpaceEngineers" mnemonicParsing="false" onAction="#launchSpaceEngineers" text="Launch SE" />
-                                            </buttons>
-                                        </ButtonBar>
-                                        <HBox alignment="CENTER_LEFT" spacing="10.0" />
-                                    </children>
-                                    <VBox.margin>
-                                        <Insets />
-                                    </VBox.margin>
-                                    <padding>
-                                        <Insets bottom="5.0" left="10.0" right="10.0" top="5.0" />
-                                    </padding>
-                                </HBox>
-                            </children>
-                        </VBox>
-                        <TabPane fx:id="informationPane" tabDragPolicy="REORDER">
-                            <tabs>
-                                <Tab fx:id="modDescriptionTab" onClosed="#closeModDescriptionTab" text="Mod Description">
-                                    <content>
-                                        <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="ALWAYS" maxWidth="1.7976931348623157E308">
-                                            <content>
-                                                <TextArea editable="false" />
-                                            </content>
-                                        </ScrollPane>
-                                    </content>
-                                </Tab>
-                                <Tab fx:id="logTab" onClosed="#closeLogTab" text="Log">
-                                    <content>
-                                        <ListView fx:id="viewableLog" focusTraversable="false" />
-                                    </content>
-                                </Tab>
-                            </tabs>
-                            <padding>
-                                <Insets bottom="5.0" />
-                            </padding>
-                        </TabPane>
-                    </items>
-                </SplitPane>
-            </center>
+        <BorderPane fx:id="mainWindowLayout" layoutY="27.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                    AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         </BorderPane>
     </children>
 </AnchorPane>

--- a/src/main/resources/view/menubar.fxml
+++ b/src/main/resources/view/menubar.fxml
@@ -131,7 +131,7 @@
                  </HBox>
                  <StackPane alignment="TOP_CENTER">
                      <children>
-                         <TextField fx:id="modTableSearchBox" promptText="Search Modlist" />
+                         <TextField fx:id="modTableSearchField" promptText="Search Modlist" />
                          <StackPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" StackPane.alignment="CENTER_RIGHT">
                              <children>
                                  <FontIcon iconLiteral="ci-close" iconSize="16" />

--- a/src/main/resources/view/modlist-manager.fxml
+++ b/src/main/resources/view/modlist-manager.fxml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<?import javafx.geometry.Insets?>
+<SplitPane fx:id="mainViewSplit" dividerPositions="0.7" orientation="VERTICAL" BorderPane.alignment="CENTER" xmlns:fx="http://javafx.com/fxml/1">
+    <VBox>
+        <ScrollPane fitToHeight="true" fitToWidth="true" VBox.vgrow="ALWAYS">
+            <TableView fx:id="modTable" maxHeight="1.7976931348623157E308"
+                       maxWidth="1.7976931348623157E308">
+                <placeholder>
+                    <Label text="No Mods Installed"/>
+                </placeholder>
+                <columns>
+                    <TableColumn fx:id="modName" prefWidth="200.0" text="Mod Name"/>
+                    <TableColumn fx:id="loadPriority" prefWidth="85.0" text="Priority"/>
+                    <TableColumn fx:id="modLastUpdated" prefWidth="115.0" text="Last Updated"/>
+                    <TableColumn fx:id="modVersion" prefWidth="85.0" text="Version"/>
+                    <TableColumn fx:id="modSource" prefWidth="85.0" text="Import Source" visible="false"/>
+                    <TableColumn fx:id="modType" prefWidth="100.0" text="Source"/>
+                    <TableColumn fx:id="modCategory" prefWidth="125.0" text="Category/Tags"/>
+                </columns>
+                <columnResizePolicy>
+                    <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
+                </columnResizePolicy>
+            </TableView>
+        </ScrollPane>
+        <HBox fx:id="tableActions" alignment="CENTER_LEFT" spacing="10.0" VBox.vgrow="NEVER">
+            <children>
+                <HBox alignment="CENTER_LEFT" spacing="10.0">
+                    <children>
+                        <ComboBox fx:id="modImportDropdown" prefWidth="250.0" promptText="Add mods from..."/>
+                    </children>
+                </HBox>
+                <ButtonBar buttonOrder="U+FBIX_NCYOA_R">
+                    <buttons>
+                        <Button fx:id="importModlist" mnemonicParsing="false" text="Import Modlist"/>
+                        <Button fx:id="exportModlist" mnemonicParsing="false" text="Export Modlist"/>
+                        <Button fx:id="resetModlist" mnemonicParsing="false" text="Reset Modlist"/>
+                        <Button fx:id="injectModlist" mnemonicParsing="false" onAction="#applyModlist"
+                                text="Apply Modlist"/>
+                        <Button fx:id="launchSpaceEngineers" mnemonicParsing="false"
+                                onAction="#launchSpaceEngineers" text="Launch SE"/>
+                    </buttons>
+                </ButtonBar>
+                <HBox alignment="CENTER_LEFT" spacing="10.0"/>
+            </children>
+            <VBox.margin>
+                <Insets/>
+            </VBox.margin>
+            <padding>
+                <Insets bottom="5.0" left="10.0" right="10.0" top="5.0"/>
+            </padding>
+        </HBox>
+    </VBox>
+    <TabPane fx:id="informationPane" tabDragPolicy="REORDER">
+        <tabs>
+            <Tab fx:id="modDescriptionTab" onClosed="#closeModDescriptionTab" text="Mod Description">
+                <content>
+                    <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="ALWAYS"
+                                maxWidth="1.7976931348623157E308">
+                        <content>
+                            <TextArea editable="false"/>
+                        </content>
+                    </ScrollPane>
+                </content>
+            </Tab>
+            <Tab fx:id="logTab" onClosed="#closeLogTab" text="Log">
+                <content>
+                    <ListView fx:id="viewableLog" focusTraversable="false"/>
+                </content>
+            </Tab>
+        </tabs>
+        <padding>
+            <Insets bottom="5.0"/>
+        </padding>
+    </TabPane>
+</SplitPane>


### PR DESCRIPTION
Migrated the content that was previously in the center of the MainWindow's borderpane—nominally the mod table, the application user log, the mod descriptions tab, and the table action bar—to its its own classes and FXML file.