### PR TITLE
Fixed autoscroll never stopping when dropping rows off window

### DIFF
--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
@@ -275,7 +275,7 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 			dragEvent.consume();
 		});
 
-		//This is a dumb hack but I can't get the rows height any other way
+		//This is a dumb hack but I can't get the row's height any other way
 		if (MODLIST_MANAGER_VIEW.getSingleTableRow() == null) MODLIST_MANAGER_VIEW.setSingleTableRow(row);
 
 		return row;
@@ -298,15 +298,17 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 		}
 	}
 
+	/*
+		Gets the actual position for our load priority. If we are in descending order, we actually need to set load priority to the exact opposite number in the list from where it was dropped.
+		So if we are descending and drop the item at the very top of the list, we actually want to make its load priority the last, while keeping its actual position in the list where we dropped it.
+	 */
 	private int getIntendedLoadPriority(TableView<Mod> modTable, int index) {
-		int intendedLoadPriority;
 		//Check if we are in ascending/default order, else we're in descending order
 		if (modTable.getSortOrder().isEmpty() || modTable.getSortOrder().getFirst().getSortType().equals(TableColumn.SortType.ASCENDING)) {
 			return index;
 		} else {
-			intendedLoadPriority = UI_SERVICE.getCurrentModList().size() - index;
+			return UI_SERVICE.getCurrentModList().size() - index;
 		}
-		return intendedLoadPriority;
 	}
 
 	private String getSelectedCellBorderColor() {

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
@@ -3,6 +3,7 @@ package com.gearshiftgaming.se_mod_manager.frontend.models;
 import com.gearshiftgaming.se_mod_manager.backend.models.Mod;
 import com.gearshiftgaming.se_mod_manager.backend.models.ModType;
 import com.gearshiftgaming.se_mod_manager.frontend.domain.UiService;
+import com.gearshiftgaming.se_mod_manager.frontend.view.ModlistManagerView;
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
@@ -42,7 +43,7 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 
 	private TableRow<Mod> previousRow;
 
-	private final List<TableRow<Mod>> SINGLE_TABLE_ROW;
+	private final ModlistManagerView MODLIST_MANAGER_VIEW;
 
 	private enum RowBorderType {
 		TOP,
@@ -50,11 +51,11 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 	}
 
 
-	public ModTableRowFactory(UiService uiService, DataFormat serializedMimeType, List<Mod> selections, List<TableRow<Mod>> singleTableRow) {
+	public ModTableRowFactory(UiService uiService, DataFormat serializedMimeType, List<Mod> selections, ModlistManagerView modlistManagerView) {
 		this.UI_SERVICE = uiService;
 		this.SERIALIZED_MIME_TYPE = serializedMimeType;
 		this.SELECTIONS = selections;
-		this.SINGLE_TABLE_ROW = singleTableRow;
+		this.MODLIST_MANAGER_VIEW = modlistManagerView;
 	}
 
 
@@ -266,19 +267,17 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 			}
 		});
 
-		//TODO: Getting a bug where, when we stop dragging, if we were dragged over when we let go it keeps dragging to the top or bottom.
-		// We need to pass the timeline in and stop it. This might not work though cause of dereferencing. Might honestly at this point be better to, for both this *and* the row size stuff, move the center content to its own class and pass that as a variable here.
 		row.setOnDragDone(dragEvent -> {
-			System.out.println("Stopping scroll");
+			if (MODLIST_MANAGER_VIEW.getScrollTimeline() != null) MODLIST_MANAGER_VIEW.getScrollTimeline().stop();
+
 			// Remove any borders and perform clean-up actions here
-			previousRow.setBorder(null);
+			if (previousRow != null) previousRow.setBorder(null);
 			dragEvent.consume();
 		});
 
-		//This is a dumb hack but I can't get the damn rows any other way
-		if(SINGLE_TABLE_ROW.isEmpty()) {
-			SINGLE_TABLE_ROW.add(row);
-		}
+		//This is a dumb hack but I can't get the rows height any other way
+		if (MODLIST_MANAGER_VIEW.getSingleTableRow() == null) MODLIST_MANAGER_VIEW.setSingleTableRow(row);
+
 		return row;
 	}
 

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/ModlistManagerView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/ModlistManagerView.java
@@ -29,6 +29,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.text.Text;
 import javafx.util.Duration;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.awt.*;
 import java.io.IOException;
@@ -128,13 +129,15 @@ public class ModlistManagerView {
 
 	private ListChangeListener<TableColumn<Mod, ?>> sortListener;
 
+	@Getter
 	private Timeline scrollTimeline;
 
 	private final List<Mod> SELECTIONS;
 
-	//This list existing is a really, really dumb hack because it's impossible to get the actual row height from the table otherwise.
-	//It should only ever have one item.
-	private final List<TableRow<Mod>> SINGLE_TABLE_ROW;
+	@Getter
+	@Setter
+	//This is a really dumb hack that we have to use to actually get a row as it is styled in the application.
+	private TableRow<Mod> singleTableRow;
 
 	//TODO: We might not need this if we setup a listener properly on the active mod count, but I'm not sure how we can since it has to be done in ModNameCell.
 	private Text activeModCount;
@@ -158,7 +161,6 @@ public class ModlistManagerView {
 
 		SERIALIZED_MIME_TYPE = new DataFormat("application/x-java-serialized-object");
 		SELECTIONS = new ArrayList<>();
-		SINGLE_TABLE_ROW = new ArrayList<>();
 	}
 
 	public void initView(Text activeModCount, Text modConflicts, CheckMenuItem logToggle, CheckMenuItem modDescriptionToggle) {
@@ -183,7 +185,7 @@ public class ModlistManagerView {
 	private void setupModTable() {
 
 		modTable.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
-		modTable.setRowFactory(new ModTableRowFactory(UI_SERVICE, SERIALIZED_MIME_TYPE, SELECTIONS, SINGLE_TABLE_ROW));
+		modTable.setRowFactory(new ModTableRowFactory(UI_SERVICE, SERIALIZED_MIME_TYPE, SELECTIONS, this));
 
 		modName.setCellValueFactory(cellData -> new ReadOnlyObjectWrapper<>(cellData.getValue()));
 		modName.setCellFactory(param -> new ModNameCell(UI_SERVICE));
@@ -348,10 +350,11 @@ public class ModlistManagerView {
 		double maxScrollValue = verticalScrollBar.getMax();
 		double scrollAmount;
 
+
 		//Scroll up
-		if (y < modTableTop - SCROLL_THRESHOLD && currentScrollValue > minScrollValue && modTable.getItems().size() * SINGLE_TABLE_ROW.getFirst().getHeight() > modTable.getHeight()) {
+		if (y < modTableTop - SCROLL_THRESHOLD && currentScrollValue > minScrollValue && modTable.getItems().size() * singleTableRow.getHeight() > modTable.getHeight()) {
 			scrollAmount = -SCROLL_SPEED * 0.1;
-		} else if (y > modTableBottom + SCROLL_THRESHOLD && currentScrollValue < maxScrollValue && modTable.getItems().size() * SINGLE_TABLE_ROW.getFirst().getHeight() > modTable.getHeight()) {
+		} else if (y > modTableBottom + SCROLL_THRESHOLD && currentScrollValue < maxScrollValue && modTable.getItems().size() * singleTableRow.getHeight() > modTable.getHeight()) {
 			scrollAmount = SCROLL_SPEED * 0.1;
 		} else {
 			scrollAmount = 0;


### PR DESCRIPTION
Fixed the autoscroll animation timeline never stopping when you drag and drop rows off the the window and drop them. This was achieved by passing the ModlistManagerView object to the ModTableRowFactory and stopping the timer when a dragDone event is triggered.