### PR TITLE
Improved mod table UX

### DIFF
--- a/src/main/java/com/gearshiftgaming/se_mod_manager/controller/ViewController.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/controller/ViewController.java
@@ -100,7 +100,6 @@ public class ViewController {
 		}
 	}
 
-	//TODO: Move all the content in the center of the MainWindowView into its own fxml and class file.
 	private void setupInterface(Stage stage) throws IOException, XmlPullParserException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
 		//Manually inject our controllers into our FXML so we can reuse the FXML for the profile creation elsewhere, and have greater flexibility in controller injection and FXML initialization.
 		//This method also allows us to properly define constructors for the view objects which is otherwise not feasible with JavaFX.

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRow.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRow.java
@@ -51,19 +51,19 @@ public class ModTableRow extends TableRow<Mod> {
 		}
 	}
 
-	//TODO: Maybe make them a brighter color? Like, for light make it blue. Not sure for darks. Red? Green for Dracula? Some better color contrast would work a LOT better.
+	//TODO: Maybe make them a brighter color? Like, for light themes make it blue. Not sure for darks. Red? Some better color contrast would look a lot better. Look at what Dracula does.
 	//This is an extremely clunky way of doing this, and it's pretty dependent on the atlantaFX implementation, but I'm an idiot and can't figure out another way to actually get the damn current CSS style from my stylesheet, then add onto it.
 	private String getSelectedCellColor(String themeName) {
 		return switch (themeName) {
 			case "PrimerLight", "NordLight", "CupertinoLight": yield
 					"-color-cell-bg-selected: -color-base-2;" +
-					"-color-cell-bg-selected-focused: -color-base-2;";
+					"-color-cell-bg-selected-focused: -color-accent-2;";
 			case "PrimerDark", "CupertinoDark": yield
 					"-color-cell-bg-selected: -color-base-5;" +
-					"-color-cell-bg-selected-focused: -color-base-5;";
+					"-color-cell-bg-selected-focused: -color-accent-5;";
 			case "NordDark": yield
 					"-color-cell-bg-selected: -color-base-6;" +
-					"-color-cell-bg-selected-focused: -color-base-6;";
+					"-color-cell-bg-selected-focused: -color-accent-6;";
 			default: yield
 					"-color-cell-bg-selected: -color-accent-subtle;" +
 					"-color-cell-bg-selected-focused: -color-accent-subtle;";

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
@@ -176,6 +176,7 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 			if (!row.isEmpty() && previousRow.getItem().equals(modTable.getItems().getLast())) {
 				//Our if conditions are organized this way because the .lookup function is not wholly inexpensive and it's getting called often.
 				ScrollBar verticalScrollBar = (ScrollBar) modTable.lookup(".scroll-bar:vertical");
+				//We don't want to add a border if the table isn't big enough to display all mods at once since we'll end up with a double border
 				if (!verticalScrollBar.isVisible()) {
 					addBorderToRow(RowBorderType.BOTTOM, modTable, row);
 				} else {

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/models/ModTableRowFactory.java
@@ -120,16 +120,6 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 						.then(TABLE_CONTEXT_MENU)
 						.otherwise((ContextMenu) null));
 
-		//TODO: Change the cursor so it has a dragboard of the rows, but also clearly indicates that the operation isn't supported.
-		// Can use a font icon for this, like so:
-//		fontIcon.setIconSize(Math.min(width, height)); // size should be within bounds
-//
-//		SnapshotParameters parameters = new SnapshotParameters();
-//		parameters.setFill(backgroundColor != null ? backgroundColor : Color.TRANSPARENT);
-//
-//		WritableImage image = new WritableImage(width, height);
-//		fontIcon.snapshot(parameters, image);
-
 		//Setup drag and drop reordering for the table
 		row.setOnDragDetected(dragEvent -> {
 			//Don't allow dragging if a sortOrder is applied, or if the sort order that's applied isn't an ascending sort on loadPriority
@@ -170,6 +160,7 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 
 			if (!row.isEmpty()) {
 				previousRow = row;
+				MODLIST_MANAGER_VIEW.setPreviousRow(previousRow);
 			}
 
 			if (dragEvent.getDragboard().hasContent(SERIALIZED_MIME_TYPE)) {
@@ -182,8 +173,14 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 
 		row.setOnDragExited(dragEvent -> {
 			//If we are not the last item and the row isn't blank, set it to null. Else, set a bottom border.
-			if (!row.isEmpty() && row.getIndex() == modTable.getItems().size() - 1) {
-				addBorderToRow(RowBorderType.BOTTOM, modTable, row);
+			if (!row.isEmpty() && previousRow.getItem().equals(modTable.getItems().getLast())) {
+				//Our if conditions are organized this way because the .lookup function is not wholly inexpensive and it's getting called often.
+				ScrollBar verticalScrollBar = (ScrollBar) modTable.lookup(".scroll-bar:vertical");
+				if (!verticalScrollBar.isVisible()) {
+					addBorderToRow(RowBorderType.BOTTOM, modTable, row);
+				} else {
+					row.setBorder(null);
+				}
 			} else {
 				row.setBorder(null);
 			}
@@ -239,6 +236,7 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 				dragEvent.setDropCompleted(true);
 				SELECTIONS.clear();
 
+				//TODO: Move to a helper class
 				//If we are ascending or not sorted then set the load priority equal to the spot in the list, minus one.
 				//If we are descending then set the load priority to its inverse position.
 				if (modTable.getSortOrder().isEmpty() || modTable.getSortOrder().getFirst().getSortType().equals(TableColumn.SortType.ASCENDING)) {
@@ -292,7 +290,7 @@ public class ModTableRowFactory implements Callback<TableView<Mod>, TableRow<Mod
 			} else {
 				dropIndicator = new Border(new BorderStroke(indicatorColor, indicatorColor, indicatorColor, indicatorColor,
 						BorderStrokeStyle.NONE, BorderStrokeStyle.NONE, BorderStrokeStyle.SOLID, BorderStrokeStyle.NONE,
-						CornerRadii.EMPTY, new BorderWidths(2), Insets.EMPTY));
+						CornerRadii.EMPTY, new BorderWidths(2), new Insets(0, 0, 2, 0)));
 			}
 			row.setBorder(dropIndicator);
 		}

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MenuBarView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/MenuBarView.java
@@ -12,6 +12,9 @@ import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.TransferMode;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.util.StringConverter;
 import lombok.Getter;
@@ -32,6 +35,9 @@ import java.util.List;
 public class MenuBarView {
 
 	//FXML Items
+	@FXML
+	private VBox menuBarRoot;
+
 	@FXML
 	private MenuItem saveModlistAs;
 
@@ -107,7 +113,6 @@ public class MenuBarView {
 	@FXML
 	private CheckMenuItem draculaTheme;
 
-	//TODO: Should replace this with a ModlistManagerView
 	private final ModlistManagerView MODLIST_MANAGER_VIEW;
 
 	private final List<CheckMenuItem> THEME_LIST = new ArrayList<>();

--- a/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/ModlistManagerView.java
+++ b/src/main/java/com/gearshiftgaming/se_mod_manager/frontend/view/ModlistManagerView.java
@@ -99,7 +99,7 @@ public class ModlistManagerView {
 	private TableColumn<Mod, String> modCategory;
 
 	@FXML
-	private HBox tableActions;
+	private HBox actions;
 
 	@FXML
 	@Getter
@@ -185,9 +185,9 @@ public class ModlistManagerView {
 
 		setupMainViewItems();
 		setupModTable();
-		tableActions.setOnDragDropped(this::handleTableActionsOnDragDrop);
-		tableActions.setOnDragOver(this::handleTableActionsOnDragOver);
-		tableActions.setOnDragExited(this::handleTableActionsOnDragExit);
+		actions.setOnDragDropped(this::handleTableActionsOnDragDrop);
+		actions.setOnDragOver(this::handleTableActionsOnDragOver);
+		actions.setOnDragExited(this::handleTableActionsOnDragExit);
 	}
 
 	//TODO: If our mod profile is null but we make a save, popup mod profile UI too. And vice versa for save profile.
@@ -363,7 +363,7 @@ public class ModlistManagerView {
 		//Scroll up
 		if (y < modTableTop && currentScrollValue > minScrollValue && modTable.getItems().size() * singleTableRow.getHeight() > modTable.getHeight()) {
 			scrollAmount = -SCROLL_SPEED * 0.1;
-		} else if (y > modTableBottom + tableActions.getHeight() && currentScrollValue < maxScrollValue && modTable.getItems().size() * singleTableRow.getHeight() > modTable.getHeight()) { //Scroll down
+		} else if (y > modTableBottom + actions.getHeight() && currentScrollValue < maxScrollValue && modTable.getItems().size() * singleTableRow.getHeight() > modTable.getHeight()) { //Scroll down
 			scrollAmount = SCROLL_SPEED * 0.1;
 		} else {
 			scrollAmount = 0;
@@ -389,7 +389,7 @@ public class ModlistManagerView {
 			}
 		}
 
-		if (y > modTableTop + headerRow.getHeight() && y < modTableBottom + tableActions.getHeight()) {
+		if (y > modTableTop + headerRow.getHeight() && y < modTableBottom + actions.getHeight()) {
 			dragEvent.acceptTransferModes(TransferMode.MOVE);
 		}
 
@@ -400,7 +400,7 @@ public class ModlistManagerView {
 	private void handleTableActionsOnDragDrop(DragEvent dragEvent) {
 		Dragboard dragboard = dragEvent.getDragboard();
 
-		tableActions.setBorder(null);
+		actions.setBorder(null);
 
 		//TODO:
 		/*
@@ -460,12 +460,12 @@ public class ModlistManagerView {
 			dropIndicator = new Border(new BorderStroke(indicatorColor, indicatorColor, indicatorColor, indicatorColor,
 					BorderStrokeStyle.SOLID, BorderStrokeStyle.NONE, BorderStrokeStyle.NONE, BorderStrokeStyle.NONE,
 					CornerRadii.EMPTY, new BorderWidths(2, 0, 0, 0), new Insets(-2, verticalScrollBar.getWidth(), 0, 0)));
-			tableActions.setBorder(dropIndicator);
+			actions.setBorder(dropIndicator);
 		}
 	}
 
 	private void handleTableActionsOnDragExit(DragEvent dragEvent) {
-		tableActions.setBorder(null);
+		actions.setBorder(null);
 	}
 
 	private int getIntendedLoadPriority(TableView<Mod> modTable, int index) {

--- a/src/main/resources/view/menubar.fxml
+++ b/src/main/resources/view/menubar.fxml
@@ -17,7 +17,7 @@
 <?import javafx.scene.text.Text?>
 <?import org.kordamp.ikonli.javafx.FontIcon?>
 
-<VBox xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="menuBarRoot" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
      <children>
          <MenuBar prefWidth="1000.0">
              <menus>

--- a/src/main/resources/view/modlist-manager.fxml
+++ b/src/main/resources/view/modlist-manager.fxml
@@ -26,7 +26,7 @@
                 </columnResizePolicy>
             </TableView>
         </ScrollPane>
-        <HBox fx:id="tableActions" alignment="CENTER_LEFT" spacing="10.0" VBox.vgrow="NEVER">
+        <HBox fx:id="actions" alignment="CENTER_LEFT" spacing="10.0" VBox.vgrow="NEVER">
             <children>
                 <HBox alignment="CENTER_LEFT" spacing="10.0">
                     <children>


### PR DESCRIPTION
Changed the color of selected rows for all themes to brighter, more colorful, and visually distinct colors. Additionally, implemented a fix for the cursor not changing to an invalid cursor when a row was dragged outside of the valid drop area. This was achieved by adjusting the edge scrolling zone to being properly matched to the table header and action bar, respectfully, and then if we are scrolling we set the event acceptTransferModes to none.

A fix was also implemented for the issue of the row drop indicator not properly appearing at the very bottom of the table when dragging. This was achieved by making a border appear on the top of the actions bar with a width that is subtracted by the width of the scrollbar, only if the scrollbar is visible and its position is at the very lowest it can go, also known as its max position. The border added to the top of the actions bar is also inset by a negative value equal to the thickness of the border so it appears as if it's on the row itself. A second check was added in the ModTableRowFactory so that, if the scrollbar is not visible, we do still add a normal border to the bottom of our bottom most row.

Last, an improvement was made so that if you drag a row over the actions bar, which is part of the valid drop area, unless you are actually scrolled all the way at the bottom of the table, it won't drop the row and it won't display a border on the actions bar.